### PR TITLE
Fix desktop startup crash on launch

### DIFF
--- a/frontend/src/components/Editor/EditorWrapper.jsx
+++ b/frontend/src/components/Editor/EditorWrapper.jsx
@@ -491,54 +491,6 @@ const EditorWrapper = ({
     });
   }, [editor, findMatches, activeFindMatchIndex, showSource]);
 
-  useEffect(() => {
-    const handleFindShortcut = (event) => {
-      if ((event.ctrlKey || event.metaKey) && !event.shiftKey && event.key.toLowerCase() === 'f') {
-        event.preventDefault();
-        setShowFindBar(true);
-        focusFindInput();
-      } else if ((event.ctrlKey || event.metaKey) && !event.shiftKey && event.key.toLowerCase() === 's') {
-        event.preventDefault();
-        onSaveFileClick();
-      } else if ((event.ctrlKey || event.metaKey) && event.shiftKey && event.key.toLowerCase() === 'p') {
-        event.preventDefault();
-        togglePreview();
-      } else if ((event.ctrlKey || event.metaKey) && event.shiftKey && event.key.toLowerCase() === 'd') {
-        event.preventDefault();
-        toggleDiff();
-      } else if ((event.ctrlKey || event.metaKey) && event.shiftKey && event.key.toLowerCase() === 's') {
-        event.preventDefault();
-        handleToggleSource();
-      } else if ((event.ctrlKey || event.metaKey) && event.shiftKey && event.key.toLowerCase() === 'e') {
-        event.preventDefault();
-        onToggleTrackChanges();
-      } else if ((event.ctrlKey || event.metaKey) && event.shiftKey && event.key.toLowerCase() === 'r') {
-        event.preventDefault();
-        handleRenderInlineR();
-      } else if ((event.ctrlKey || event.metaKey) && event.altKey && event.key.toLowerCase() === 'z') {
-        event.preventDefault();
-        handleCiteZoteroShortcut();
-      } else if ((event.ctrlKey || event.metaKey) && event.altKey && event.key.toLowerCase() === 'm') {
-        event.preventDefault();
-        handleAddCommentShortcut();
-      } else if (event.key === 'Escape') {
-        setShowFindBar(false);
-      }
-    };
-
-    window.addEventListener('keydown', handleFindShortcut);
-    return () => window.removeEventListener('keydown', handleFindShortcut);
-  }, [
-    focusFindInput,
-    handleAddCommentShortcut,
-    handleCiteZoteroShortcut,
-    handleRenderInlineR,
-    handleToggleSource,
-    onToggleTrackChanges,
-    toggleDiff,
-    togglePreview,
-  ]);
-
   const handleRenderInlineR = useCallback(async () => {
     if (!editor || isRenderingInlineR) return;
     setIsRenderingInlineR(true);
@@ -759,6 +711,55 @@ const EditorWrapper = ({
     setCommitMsg('');
     setShowCommitDialog(true);
   };
+
+  useEffect(() => {
+    const handleFindShortcut = (event) => {
+      if ((event.ctrlKey || event.metaKey) && !event.shiftKey && event.key.toLowerCase() === 'f') {
+        event.preventDefault();
+        setShowFindBar(true);
+        focusFindInput();
+      } else if ((event.ctrlKey || event.metaKey) && !event.shiftKey && event.key.toLowerCase() === 's') {
+        event.preventDefault();
+        onSaveFileClick();
+      } else if ((event.ctrlKey || event.metaKey) && event.shiftKey && event.key.toLowerCase() === 'p') {
+        event.preventDefault();
+        togglePreview();
+      } else if ((event.ctrlKey || event.metaKey) && event.shiftKey && event.key.toLowerCase() === 'd') {
+        event.preventDefault();
+        toggleDiff();
+      } else if ((event.ctrlKey || event.metaKey) && event.shiftKey && event.key.toLowerCase() === 's') {
+        event.preventDefault();
+        handleToggleSource();
+      } else if ((event.ctrlKey || event.metaKey) && event.shiftKey && event.key.toLowerCase() === 'e') {
+        event.preventDefault();
+        onToggleTrackChanges();
+      } else if ((event.ctrlKey || event.metaKey) && event.shiftKey && event.key.toLowerCase() === 'r') {
+        event.preventDefault();
+        handleRenderInlineR();
+      } else if ((event.ctrlKey || event.metaKey) && event.altKey && event.key.toLowerCase() === 'z') {
+        event.preventDefault();
+        handleCiteZoteroShortcut();
+      } else if ((event.ctrlKey || event.metaKey) && event.altKey && event.key.toLowerCase() === 'm') {
+        event.preventDefault();
+        handleAddCommentShortcut();
+      } else if (event.key === 'Escape') {
+        setShowFindBar(false);
+      }
+    };
+
+    window.addEventListener('keydown', handleFindShortcut);
+    return () => window.removeEventListener('keydown', handleFindShortcut);
+  }, [
+    focusFindInput,
+    handleAddCommentShortcut,
+    handleCiteZoteroShortcut,
+    handleRenderInlineR,
+    handleToggleSource,
+    onSaveFileClick,
+    onToggleTrackChanges,
+    toggleDiff,
+    togglePreview,
+  ]);
 
   const onCommitConfirm = async () => {
     setShowCommitDialog(false);

--- a/frontend/src/components/WarningBanner.js
+++ b/frontend/src/components/WarningBanner.js
@@ -2,19 +2,18 @@ import React from 'react';
 import { getCurrentTime, isWithin30Minutes } from '../utils/timeUtils';
 
 const WarningBanner = ({ editors, currentUser }) => {
-  console.log('WarningBanner rendering with editors:', editors);
-
-  if (!editors || editors.length === 0) return null;
+  if (!Array.isArray(editors) || editors.length === 0) return null;
 
   const now = new Date(getCurrentTime());
   const activeEditors = editors.filter(editor => isWithin30Minutes(editor.timestamp));
+  const currentUserName = currentUser?.name || currentUser?.login || null;
 
   if (activeEditors.length === 0) return null;
 
-  const isFirstUser = activeEditors[0].name === (currentUser.name || currentUser.login);
-  const otherEditors = activeEditors.filter(editor => 
-    editor.name !== (currentUser.name || currentUser.login)
-  );
+  const isFirstUser = currentUserName ? activeEditors[0].name === currentUserName : false;
+  const otherEditors = currentUserName
+    ? activeEditors.filter(editor => editor.name !== currentUserName)
+    : activeEditors.slice(1);
 
   const renderMessage = () => {
     if (isFirstUser) {

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -20,16 +20,21 @@ const api = axios.create({
   }
 });
 
+const isExpectedUnauthorized = (error) =>
+  error?.response?.status === 401 && error?.config?.url?.includes('/api/user');
+
 // Add response interceptor for debugging
 api.interceptors.response.use(
   response => response,
   error => {
-    console.error('API Error:', {
-      message: error.message,
-      response: error.response?.data,
-      status: error.response?.status,
-      headers: error.response?.headers
-    });
+    if (!isExpectedUnauthorized(error)) {
+      console.error('API Error:', {
+        message: error.message,
+        response: error.response?.data,
+        status: error.response?.status,
+        headers: error.response?.headers
+      });
+    }
     return Promise.reject(error);
   }
 );
@@ -111,7 +116,9 @@ export const fetchUser = async () => {
     const res = await api.get('/api/user');
     return res.data;
   } catch (err) {
-    console.error('Error fetching user:', err);
+    if (!isExpectedUnauthorized(err)) {
+      console.error('Error fetching user:', err);
+    }
     return null;
   }
 };


### PR DESCRIPTION
## Summary
- as noted in #7 I had a launch bug, I had codex fix it, it fixed it for me, yoo could/should check it still builds on windows before merging
- move the editor keyboard-shortcut effect below the callback definitions it depends on to avoid the production startup crash from temporal dead zone access
- guard WarningBanner against missing editor/current-user data during startup
- suppress expected unauthenticated /api/user logging noise during desktop startup

## Verification
- npm test --prefix frontend
- npm run build --prefix frontend
- npm run build:mac --prefix electron
- node scripts/electron-smoke.mjs dist/mac-arm64/QuartoReview.app/Contents/MacOS/QuartoReview
